### PR TITLE
pkg/kcov: add Go-native KCOV collection

### DIFF
--- a/pkg/kcov/cdefs.go
+++ b/pkg/kcov/cdefs.go
@@ -1,0 +1,43 @@
+package kcov
+
+import "unsafe"
+
+const (
+	// sizeof(uintptr)
+	sizeofUintPtr = 8
+)
+
+const (
+	_IOC_NRBITS   = 8
+	_IOC_TYPEBITS = 8
+	_IOC_SIZEBITS = 14
+	_IOC_DIRBITS  = 2
+
+	_IOC_NRSHIFT   = 0
+	_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS
+	_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS
+	_IOC_DIRSHIFT  = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+	_IOC_NONE  = 0
+	_IOC_WRITE = 1
+	_IOC_READ  = 2
+)
+
+// KCOV ioctl commands for Linux.
+const (
+	// KCOV_INIT_TRACE initializes kcov tracing.
+	// #define KCOV_INIT_TRACE _IOR('c', 1, unsigned long)
+	// On amd64, unsigned long is 8 bytes.
+	KCOV_INIT_TRACE uintptr = (_IOC_READ << _IOC_DIRSHIFT) | (uintptr(unsafe.Sizeof(uint64(0))) << _IOC_SIZESHIFT) | ('c' << _IOC_TYPESHIFT) | (1 << _IOC_NRSHIFT) // 0x80086301
+
+	// KCOV_ENABLE enables kcov for the current thread.
+	// #define KCOV_ENABLE _IO('c', 100)
+	KCOV_ENABLE uintptr = (_IOC_NONE << _IOC_DIRSHIFT) | (0 << _IOC_SIZESHIFT) | ('c' << _IOC_TYPESHIFT) | (100 << _IOC_NRSHIFT) // 0x6364
+
+	// KCOV_DISABLE disables kcov for the current thread.
+	// #define KCOV_DISABLE _IO('c', 101)
+	KCOV_DISABLE uintptr = (_IOC_NONE << _IOC_DIRSHIFT) | (0 << _IOC_SIZESHIFT) | ('c' << _IOC_TYPESHIFT) | (101 << _IOC_NRSHIFT) // 0x6365
+
+	KCOV_TRACE_PC  = 0
+	KCOV_TRACE_CMP = 1
+)

--- a/pkg/kcov/kcov.go
+++ b/pkg/kcov/kcov.go
@@ -1,0 +1,100 @@
+// Package kcov provides Go native code for reading kernel coverage.
+package kcov
+
+import (
+	"os"
+	"runtime"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const kcovPath string = "/sys/kernel/debug/kcov"
+
+const (
+	kcovCoverSize = 64 << 10
+)
+
+// Holds resources for a single traced thread.
+type KCOVState struct {
+	file  *os.File
+	cover []byte
+}
+
+// Trace invokes `f` and returns its result, as well as collected kernel
+// coverage during its invocation.
+func (st *KCOVState) Trace(f func() error) ([]uintptr, error) {
+	// First 8 bytes holds the number of collected PCs since last poll.
+	countPtr := (*uint64)(unsafe.Pointer(&st.cover[0]))
+	// Reset coverage for this run.
+	atomic.StoreUint64(countPtr, 0)
+	// Trigger call.
+	err := f()
+	// Load the number of PCs that were hit during trigger.
+	n := atomic.LoadUint64(countPtr)
+	if n == 0 {
+		return nil, nil
+	}
+
+	pcDataPtr := (*uintptr)(unsafe.Pointer(&st.cover[sizeofUintPtr]))
+	pcs := unsafe.Slice(pcDataPtr, n)
+	pcsCopy := make([]uintptr, n)
+	copy(pcsCopy, pcs)
+	return pcsCopy, err
+}
+
+// EnableTracingForCurrentGoroutine prepares the current goroutine for kcov tracing.
+// It must be paired with a call to DisableTracing.
+func EnableTracingForCurrentGoroutine() (*KCOVState, error) {
+	// KCOV is per-thread, so lock goroutine to its current OS thread.
+	runtime.LockOSThread()
+
+	file, err := os.OpenFile(kcovPath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanupOnError := func() {
+		file.Close()
+		runtime.UnlockOSThread()
+	}
+
+	fd := file.Fd()
+
+	// Setup trace mode and size.
+	if err := unix.IoctlSetInt(int(fd), uint(KCOV_INIT_TRACE), kcovCoverSize); err != nil {
+		cleanupOnError()
+		return nil, err
+	}
+
+	// Mmap buffer shared between kernel- and user-space.
+	coverageBuffer, err := unix.Mmap(
+		int(fd),
+		0, // offset
+		kcovCoverSize*sizeofUintPtr,
+		unix.PROT_READ|unix.PROT_WRITE, // a read/write mapping
+		unix.MAP_SHARED,                // changes are shared with the kernel
+	)
+	if err != nil {
+		cleanupOnError()
+		return nil, err
+	}
+
+	// Enable coverage collection on the current thread.
+	if err := unix.IoctlSetInt(int(fd), uint(KCOV_ENABLE), KCOV_TRACE_PC); err != nil {
+		cleanupOnError()
+		unix.Munmap(coverageBuffer)
+		return nil, err
+	}
+
+	return &KCOVState{
+		file:  file,
+		cover: coverageBuffer,
+	}, nil
+}
+
+func (st *KCOVState) DisableTracing() {
+	runtime.UnlockOSThread()
+	st.file.Close()
+}


### PR DESCRIPTION
Currently, KCOV collection is handled exclusively by the C++ executor. This prevents standalone tools, like the in-progress syz-kfuzztest standalone tool that fuzzes inside the VM, from performing coverage-guided fuzzing.

This change introduces the new pkg/kcov package, providing functions to set up and collect kernel coverage directly from Go. This enables Go programs in the syzkaller ecosystem to benefit from coverage feedback without depending on the C++ executor.
