### PR TITLE
pkg/prog: update marshalling for kfuzztest input arguments

### DIFF
--- a/prog/encodingexec.go
+++ b/prog/encodingexec.go
@@ -151,7 +151,7 @@ func (w *execContext) serializeKFuzzTestCall(c *Call) {
 		panic("serializeKFuzzTestCall called on an invalid syscall")
 	}
 
-	// Write the initial string argument (test name) normally
+	// Write the initial string argument (test name) normally.
 	w.writeCopyin(&Call{Meta: c.Meta, Args: []Arg{c.Args[0]}})
 
 	// Args[1] is the second argument to syz_kfuzztest_run, which is a pointer
@@ -175,7 +175,7 @@ func (w *execContext) serializeKFuzzTestCall(c *Call) {
 
 	// Update the value of the length arg which should now match the length of
 	// the byte array that we created. Previously, it contained the bytesize
-	// of the struct argument passed into the pseudo-syscall
+	// of the struct argument passed into the pseudo-syscall.
 	lenArg := c.Args[2].(*ConstArg)
 	lenArg.Val = uint64(len(finalBlob))
 
@@ -249,8 +249,11 @@ func (w *execContext) writeCopyin(c *Call) {
 // Special value for making null pointers that equals (void *)-1
 const kFuzzTestNilPtrVal uint64 = ^uint64(0)
 
-// Number of integers of padding
-const relocationTablePaddingInts uint32 = 2
+// Number of integers of padding.
+const relocationTablePaddingInts uint32 = 7
+
+// Number of uint64s of padding.
+const regionArrayPaddingLongs uint32 = 3
 
 // marshallKFuzztestArg serializes a top-level struct argument (`topLevel`) into
 // a single binary blob that can be consumed by the kernel. The output format,
@@ -263,6 +266,8 @@ const relocationTablePaddingInts uint32 = 2
 // pointer arguments are found, the pointed-to data will be laid out directly
 // after the structure that the pointer is found in.
 //
+// TODO: update comments as they are outdated.
+
 // The process works as follows:
 //  1. All non-pointer fields of the input struct are processed first from a
 //     queue, and their raw data is written sequentially into the main `payload`
@@ -278,53 +283,116 @@ const relocationTablePaddingInts uint32 = 2
 //  4. Finally, the completed `relocation_table` is serialized and prepended to
 //     the `payload` buffer to form the complete binary blob.
 func marshallKFuzztestArg(topLevel Arg) []byte {
-	type deferredPtr struct {
-		pointedToArg Arg
-		pointer      uint64
-	}
 	// see `linux/include/kftf.h`
 	type relocationEntry struct {
-		pointer uint64
-		value   uint64
+		// Region that a pointer belongs to.
+		regionID uint64
+		// Offset within its own region.
+		regionOffset uint64
+		// Contains a region identifier, or kfuzzTestNilPtrVal if nil.
+		value uint64
+	}
+	// Defines a unit of allocation made by the KFuzzTest parser.
+	type relocRegion struct {
+		// Identifier for this region, corresponding to its index in the
+		// resulting relocation region array. See `include/linux/kftf.h`
+		id uint64
+		// Offset of the start of the region in the payload.
+		start uint64
+		// Size of the region in bytes.
+		size uint64
+		// Alignment of this region (not important for now, as every allocation
+		// in the kernel will be 8-byte aligned which should suffice for now).
+		alignment uint64
+	}
+	// Argument bundled with the memory region that it belongs to.
+	type argWithRegionID struct {
+		arg      Arg
+		regionID uint64
 	}
 	// Given a slice of relocation table entries, encodes them in the binary
 	// format expected by the kernel.
-	generateRelocationTable := func(relocationTableEntries []relocationEntry, maxAlignment uint32) []byte {
+	generateRelocationTable := func(relocationTableEntries []relocationEntry) []byte {
 		var relocationTable bytes.Buffer
 		numEntries := int32(len(relocationTableEntries))
 		padding := make([]byte, relocationTablePaddingInts*4)
 		binary.Write(&relocationTable, binary.LittleEndian, numEntries)
-		binary.Write(&relocationTable, binary.LittleEndian, maxAlignment)
 		binary.Write(&relocationTable, binary.LittleEndian, padding)
 		for _, entry := range relocationTableEntries {
-			binary.Write(&relocationTable, binary.LittleEndian, uint64(entry.pointer))
+			binary.Write(&relocationTable, binary.LittleEndian, uint64(entry.regionID))
+			binary.Write(&relocationTable, binary.LittleEndian, uint64(entry.regionOffset))
 			binary.Write(&relocationTable, binary.LittleEndian, uint64(entry.value))
+			binary.Write(&relocationTable, binary.LittleEndian, uint64(0)) // Padding.
 		}
 		return relocationTable.Bytes()
 	}
+	// Given a map of discovered regions, generates the region table encoded
+	// in the binary format expected by the kernel.
+	generateRegionArray := func(regionsMap map[Arg]relocRegion) []byte {
+		var regionArray bytes.Buffer
 
-	// It is possible that the fuzzer will pass an invalid pointer to the
-	// executor. In this case, to maintain compatibility to with the protocol
-	// running on the kernel, we just output an empty relocation table.
-	if topLevel == nil {
-		return generateRelocationTable([]relocationEntry{}, 1)
+		arr := make([]relocRegion, len(regionsMap))
+		for _, region := range regionsMap {
+			// Since the regionID encodes its index in the regions array, and
+			// is monotonically increasing.
+			arr[region.id] = region
+		}
+		numEntries := uint64(len(arr))
+		padding := make([]byte, regionArrayPaddingLongs*8)
+		binary.Write(&regionArray, binary.LittleEndian, numEntries)
+		binary.Write(&regionArray, binary.LittleEndian, padding)
+
+		for _, region := range arr {
+			binary.Write(&regionArray, binary.LittleEndian, region.id)
+			binary.Write(&regionArray, binary.LittleEndian, region.start)
+			binary.Write(&regionArray, binary.LittleEndian, region.size)
+			binary.Write(&regionArray, binary.LittleEndian, region.alignment)
+		}
+		return regionArray.Bytes()
 	}
 
+	// It is possible that the fuzzer will pass an invalid pointer to the
+	// executor. In this case, we send an empty relocation table and region
+	// array.
+	if topLevel == nil {
+		return append(generateRelocationTable([]relocationEntry{}), generateRegionArray(make(map[Arg]relocRegion))...)
+	}
+
+	// The top-level argument should always be a struct, and therefore of type
+	// GroupArg.
+	switch topLevel.(type) {
+	case *GroupArg:
+	default:
+		panic("top-level argument was not a GroupArg")
+	}
+
+	// Allocates a new heap region.
+	regionCtr := uint64(0)
+	allocRegion := func(size uint64, alignment uint64) relocRegion {
+		reg := relocRegion{id: regionCtr, size: size, alignment: alignment}
+		regionCtr++
+		return reg
+	}
+
+	// Allocate a region for the top-level argument. This is always region 0,
+	// irrespective on whether there are other regions or not. We currently
+	// set the alignment to 0x8. TODO: handle this alignment in kernel.
+	regionForTopLevel := allocRegion(topLevel.Size(), 0x8)
+
 	// Two-levels of queuing - those that must be handled directly (constants,
-	// nested structures) and those that must be handled afterwards. This
-	// implements a level-order traversal starting at `topLevel` such that we
-	// only expand pointed-to data after all constants in the current structure
-	// have already been laid out in the payload.
-	layoutQueue := []Arg{topLevel}
-	deferredPointers := make([]deferredPtr, 0)
+	// nested structures) and pointee arguments whose handling should be
+	// deferred. This implements a level-order traversal starting at `topLevel`
+	// such that we only expand pointees after the structure pointing to it has
+	// been completely serialized into the payload.
+	layoutQueue := []argWithRegionID{{topLevel, regionForTopLevel.id}}
+	deferredPointers := []argWithRegionID{}
 
 	relocationTableEntries := make([]relocationEntry, 0)
-	maxAlignment := uint32(topLevel.Type().Alignment())
 	var payload bytes.Buffer
 
 	// Aligns the current position in the payload to an alignment threshold.
 	alignPayload := func(alignment uint64) {
-		// It seems that some types will have 0-alignment
+		// It seems that some types will have 0-alignment.
 		if alignment == 0 {
 			return
 		}
@@ -336,60 +404,86 @@ func marshallKFuzztestArg(topLevel Arg) []byte {
 		}
 	}
 
+	// Handle cycles created by pointer arguments, and maps a pointee to its
+	// dedicated heap allocation.
+	visited := make(map[Arg]relocRegion)
+	visited[topLevel] = regionForTopLevel
+
+	// XXX: it feels error prone to deal with this type of mutable state. It
+	// may be better to pass the offset in with the regionID.
+	offsetInRegion := uint64(0)
 	for {
 		if len(layoutQueue) == 0 && len(deferredPointers) == 0 {
 			break
 		}
 		// Pop from layoutQueue if anything is available, else pop from the
 		// deferredPointers which contains pointed-to data that we must handle
-		var arg Arg
+		var argWithReg argWithRegionID
 		if len(layoutQueue) > 0 {
-			arg = layoutQueue[0]
+			argWithReg = layoutQueue[0]
 			layoutQueue = layoutQueue[1:]
 		} else if len(deferredPointers) > 0 {
+			// Expanding a pointee. This indicates the start of a new region.
+			offsetInRegion = 0
 			// pop from deferredPointers and create a relocation table entry
-			dp := deferredPointers[0]
+			argWithReg = deferredPointers[0]
 			deferredPointers = deferredPointers[1:]
-
-			currOffset := uint64(payload.Len())
-			value := currOffset - dp.pointer
-			relocationTableEntries = append(relocationTableEntries,
-				relocationEntry{pointer: dp.pointer, value: value})
-			arg = dp.pointedToArg
+			// We now know the start of the region, and thereore can update
+			// this.
+			reg, ok := visited[argWithReg.arg]
+			if !ok {
+				panic("tried to visit a pointee without having allocated a region for it")
+			}
+			reg.start = uint64(payload.Len())
+			visited[argWithReg.arg] = reg
 		} else {
 			panic("at least one queue should have remaining entries at this point")
 		}
 
-		maxAlignment = max(maxAlignment, uint32(arg.Type().Alignment()))
-		alignPayload(arg.Type().Alignment())
+		alignPayload(argWithReg.arg.Type().Alignment())
 
-		switch a := arg.(type) {
+		sizeBeforeWrite := payload.Len()
+		switch a := argWithReg.arg.(type) {
 		case *PointerArg:
-			ptrOffset := payload.Len()
 			// We write a placeholder value. It doesn't matter what is written
 			// here because the kernel will patch these pointers based only on
-			// the relocation table.
+			// the relocation table and region array.
 			binary.Write(&payload, binary.LittleEndian, uint64(0xBFACE))
-			// Ignore nil pointers and pointers that point to empty data to
-			// avoid creating a relocation table entry.
 			if a.Res != nil && a.Res.Size() > 0 {
-				deferred := deferredPtr{
-					pointedToArg: a.Res,
-					pointer:      uint64(ptrOffset),
+				reg, contains := visited[a.Res]
+				// Allocate a new region for the pointee and queue it for
+				// expansion if we haven't visited it yet.
+				if !contains {
+					reg = allocRegion(a.Res.Size(), 8)
+					visited[a.Res] = reg
+					// Visit the new region, marking the offset as 0.
+					deferred := argWithRegionID{arg: a.Res, regionID: reg.id}
+					deferredPointers = append(deferredPointers, deferred)
 				}
-				deferredPointers = append(deferredPointers, deferred)
+				// In any case, we store the region that this pointer points to.
+				relocationTableEntries = append(relocationTableEntries, relocationEntry{
+					regionID:     argWithReg.regionID,
+					regionOffset: offsetInRegion,
+					value:        reg.id,
+				})
 			} else {
 				// NULL pointer. We directly create a relocation table entry
-				// with the reserved value for NULL pointers.
+				// with the reserved value.
 				relocationTableEntries = append(relocationTableEntries, relocationEntry{
-					pointer: uint64(ptrOffset),
-					value:   kFuzzTestNilPtrVal,
+					regionOffset: offsetInRegion,
+					value:        kFuzzTestNilPtrVal,
 				})
 			}
-		// handle non-pointer arguments by writing them into the payload buffer
+		// Handle non-pointer arguments by writing them into the payload buffer.
 		case *GroupArg:
+			offsetInGroup := uint64(0)
 			for _, inner := range a.Inner {
-				layoutQueue = append(layoutQueue, inner)
+				layoutQueue = append(layoutQueue,
+					argWithRegionID{
+						arg:      inner,
+						regionID: argWithReg.regionID,
+					})
+				offsetInGroup += inner.Size()
 			}
 		case *DataArg:
 			data := a.Data()
@@ -408,15 +502,20 @@ func marshallKFuzztestArg(topLevel Arg) []byte {
 			default:
 				panic(fmt.Sprintf("unsupported constant size: %d", a.Size()))
 			}
+			// TODO: handle union args.
 		default:
 			panic(fmt.Sprintf("tried to serialize unsupported type: %s", a.Type().Name()))
 		}
+		sizeAfterWrite := payload.Len()
+		// Update the offset within the region. Ensures that we maintain the
+		// correct relative offset.
+		offsetInRegion += uint64(sizeAfterWrite) - uint64(sizeBeforeWrite)
 	}
 
-	// loop over relocation entries
-	relocationTableBytes := generateRelocationTable(relocationTableEntries, maxAlignment)
-	out := append(relocationTableBytes, payload.Bytes()...)
-	return out
+	relocationTableBytes := generateRelocationTable(relocationTableEntries)
+	regionArrayBytes := generateRegionArray(visited)
+	out := append(relocationTableBytes, regionArrayBytes...)
+	return append(out, payload.Bytes()...)
 }
 
 func (w *execContext) willBeUsed(arg Arg) bool {


### PR DESCRIPTION
# Description

The current relocation table format would pack everything into a single
kernel heap allocation during deserialization. The problem with this is
that if a some data doesn't sit at the boundary of this region, we
cannot detect buffer overflows on it.

Every logical node in the argument graph now gets its own heap-allocated
memory region, that is exactly the right size. Even if the kernel
allocated more memory for it during kmalloc, the boundaries will still
be poisoned and as a result we should be able to catch KASAN buffer
overflows on all data.

This update involves adding new metadata to the KFuzzTest input, namely
a region array which represents the size and alignment characteristics
of every piece of data. Other updates are made to the relocation table
serialization, where now instead of storing relative offsets in order to
compute the pointer's address, we store a region identifier to express
that the pointer points to the beginning of a region (some other
argument).
